### PR TITLE
fix(iter): use saturating arithmetic to prevent overflows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exponential-backoff"
-version = "1.1.0"
+version = "1.2.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/yoshuawuyts/exponential-backoff"
 documentation = "https://docs.rs/exponential-backoff"

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -44,22 +44,22 @@ impl<'b> iter::Iterator for Iter<'b> {
         // Apply jitter. Uses multiples of 100 to prevent relying on floats.
         let jitter_factor = (self.inner.jitter * 100f32) as u32;
         let random: u32 = self.rng.gen_range(0..jitter_factor * 2);
-        let duration = duration.saturating_mul(100);
+        let mut duration = duration.saturating_mul(100);
         if random < jitter_factor {
             let jitter = duration.saturating_mul(random) / 100;
-            let duration = duration.saturating_sub(jitter);
+            duration = duration.saturating_sub(jitter);
         } else {
             let jitter = duration.saturating_mul(random / 2) / 100;
-            let duration = duration.saturating_add(jitter);
+            duration = duration.saturating_add(jitter);
         };
-        let duration = duration / 100;
+        duration /= 100;
 
         // Make sure it doesn't exceed upper / lower bounds.
         if let Some(max) = self.inner.max {
-            let duration = duration.min(max);
+            duration = duration.min(max);
         }
 
-        let duration = duration.max(self.inner.min);
+        duration = duration.max(self.inner.min);
 
         Some(duration)
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -34,3 +34,19 @@ fn iterator_completes() {
     }
     assert_eq!(counter, 1 + retries);
 }
+
+#[test]
+fn max_backoff_without_crashing() {
+    let retries = u32::MAX;
+    let min = Duration::MAX;
+    let backoff = Backoff::new(retries, min, None);
+
+    let mut counter = 0u32;
+    for _ in &backoff {
+        counter += 1;
+        if counter > 32 {
+            break;
+        }
+    }
+}
+


### PR DESCRIPTION
Hey there, thanks for your work on this crate.  I encountered what I believe are two distinct overflow bugs:

The first one is triggered when the retry counter goes above 32:

```rust

let zero = Duration::ZERO;
let backoff = Backoff::new(33, zero, None);
let mut retry_counter = 0;
for _ in &backoff { 
    println!("{retry_counter}");
    retry_counter += 1;
}
```

This is because the backoff factor is overflow when we compute `2^32`: [here](https://github.com/yoshuawuyts/exponential-backoff/blob/master/src/iterator.rs#L39)

The second overflow can be triggered when the current backoff duration is within a magnitude of `Duration::MAX`:

```rust

let max = Duration::MAX;
let backoff = Backoff::new(1, max, None);
let mut retry_counter = 0;
for _ in &backoff { 
    println!("{retry_counter}");
    retry_counter += 1;
}
```

The second overflow is less problematic, but can creep up and make an entire panic on extreme inputs, or if the growth factor is large.

This PR addresses both issues by using saturating arithmetic everywhere.