### PR TITLE
Switch from `rand` to `fastrand`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,73 +3,14 @@
 version = 3
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "exponential-backoff"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
- "rand",
+ "fastrand",
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.5"
+name = "fastrand"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "libc"
-version = "0.2.119"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-rand = "0.8"
+fastrand = "2"
 
 [dev-dependencies]

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,12 +1,12 @@
 use super::Backoff;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use fastrand::Rng;
 use std::{iter, time};
 
 /// An exponential backoff iterator.
 #[derive(Debug, Clone)]
 pub struct Iter<'b> {
     inner: &'b Backoff,
-    rng: StdRng,
+    rng: Rng,
     retry_count: u32,
 }
 
@@ -19,7 +19,7 @@ impl<'b> Iter<'b> {
         Self {
             inner,
             retry_count,
-            rng: StdRng::from_entropy(),
+            rng: Rng::new(),
         }
     }
 }
@@ -43,7 +43,7 @@ impl<'b> iter::Iterator for Iter<'b> {
 
         // Apply jitter. Uses multiples of 100 to prevent relying on floats.
         let jitter_factor = (self.inner.jitter * 100f32) as u32;
-        let random: u32 = self.rng.gen_range(0..jitter_factor * 2);
+        let random = self.rng.u32(0..jitter_factor * 2);
         let mut duration = duration.saturating_mul(100);
         if random < jitter_factor {
             let jitter = duration.saturating_mul(random) / 100;


### PR DESCRIPTION
This crate's need for randomness is for the jitter feature only, and so does not need to be cryptographically secure. As such, the lighter-weight `fastrand` crate can be used instead of `rand` to reduce the number of transitive dependencies and impact on compile times. (See the diff of `Cargo.lock` for how noticeable a difference this makes.)

The `rand` crate itself mentions `fastrand` as a simpler alternative:
https://github.com/rust-random/rand/blob/master/README.md

And `fastrand` is also used by several other popular crates - so for some projects, will already be in their dependency tree:
https://crates.io/crates/fastrand/reverse_dependencies

See also:
https://crates.io/crates/fastrand
https://docs.rs/fastrand/latest/fastrand/