### PR TITLE
always include max duration

### DIFF
--- a/src/into_iter.rs
+++ b/src/into_iter.rs
@@ -1,6 +1,6 @@
 use super::Backoff;
 use fastrand::Rng;
-use std::{iter, time};
+use std::{iter, time::Duration};
 
 /// An exponential backoff iterator.
 #[derive(Debug, Clone)]
@@ -25,7 +25,7 @@ impl IntoIter {
 }
 
 impl iter::Iterator for IntoIter {
-    type Item = Option<time::Duration>;
+    type Item = Option<Duration>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -62,11 +62,7 @@ impl iter::Iterator for IntoIter {
         duration /= 100;
 
         // Make sure it doesn't exceed upper / lower bounds.
-        if let Some(max) = self.inner.max {
-            duration = duration.min(max);
-        }
-
-        duration = duration.max(self.inner.min);
+        duration = duration.clamp(self.inner.min, self.inner.max);
 
         Some(Some(duration))
     }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,6 +1,6 @@
 use super::Backoff;
 use fastrand::Rng;
-use std::{iter, time};
+use std::{iter, time::Duration};
 
 /// An exponential backoff iterator.
 #[derive(Debug, Clone)]
@@ -25,7 +25,7 @@ impl<'b> Iter<'b> {
 }
 
 impl<'b> iter::Iterator for Iter<'b> {
-    type Item = Option<time::Duration>;
+    type Item = Option<Duration>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -62,11 +62,7 @@ impl<'b> iter::Iterator for Iter<'b> {
         duration /= 100;
 
         // Make sure it doesn't exceed upper / lower bounds.
-        if let Some(max) = self.inner.max {
-            duration = duration.min(max);
-        }
-
-        duration = duration.max(self.inner.min);
+        duration = duration.clamp(self.inner.min, self.inner.max);
 
         Some(Some(duration))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ mod iter;
 pub struct Backoff {
     retries: u32,
     min: Duration,
-    max: Option<Duration>,
+    max: Duration,
     jitter: f32,
     factor: u32,
 }
@@ -66,7 +66,7 @@ impl Backoff {
         Self {
             retries,
             min,
-            max: max.into(),
+            max: max.into().unwrap_or(Duration::MAX),
             jitter: 0.3,
             factor: 2,
         }
@@ -80,7 +80,7 @@ impl Backoff {
 
     /// Set the max duration.
     #[inline]
-    pub fn set_max(&mut self, max: Option<Duration>) {
+    pub fn set_max(&mut self, max: Duration) {
         self.max = max;
     }
 


### PR DESCRIPTION
Since Backoff always includes the space for max duration, this
simplifies the logic for clamping durations.
